### PR TITLE
Restructure fragment communication and bug fix

### DIFF
--- a/app/src/main/java/com/nsc/covidscore/LocationManualSelectionFragment.java
+++ b/app/src/main/java/com/nsc/covidscore/LocationManualSelectionFragment.java
@@ -1,6 +1,7 @@
 package com.nsc.covidscore;
 
 import android.content.Context;
+import android.content.res.AssetManager;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -25,10 +26,13 @@ import com.nsc.covidscore.room.CovidSnapshot;
 import com.nsc.covidscore.room.CovidSnapshotWithLocationViewModel;
 import com.nsc.covidscore.room.Location;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -45,7 +49,6 @@ public class LocationManualSelectionFragment extends Fragment implements Adapter
     private CovidSnapshotWithLocationViewModel vm;
     private TextView loadingTextView;
 
-    private HashMap<String, List<Location>> mapOfLocationsByState = new HashMap<>();
     private List<Location> countyLocations = new ArrayList<>();
     private Spinner state_spinner;
     private Spinner county_spinner;
@@ -86,7 +89,7 @@ public class LocationManualSelectionFragment extends Fragment implements Adapter
 
         if (bundle != null) {
             // noinspection unchecked
-            mapOfLocationsByState = (HashMap<String, List<Location>>) bundle.getSerializable(Constants.LOCATIONS_MAP_BY_STATE);
+//            mapOfLocationsByState = (HashMap<String, List<Location>>) bundle.getSerializable(Constants.LOCATIONS_MAP_BY_STATE);
             Log.i(TAG, "onCreateView: Bundle received from MainActivity");
         }
 
@@ -183,7 +186,7 @@ public class LocationManualSelectionFragment extends Fragment implements Adapter
                 Log.i(TAG, "onCreateView - mutableSelectedState: STATE SELECTED " + stateSelected);
 
                 // get counties
-                countyLocations = mapOfLocationsByState.get(stateSelected);
+                countyLocations = vm.getMapOfLocationsByState().get(stateSelected);
                 List<String> countyNamesInner = countyLocations.stream().map(Location::getCounty).sorted().collect(Collectors.toList());
                 countyNamesInner.add(0, Constants.SELECT_COUNTY);
 
@@ -218,7 +221,7 @@ public class LocationManualSelectionFragment extends Fragment implements Adapter
     }
 
     public void setInitialSpinners(View v) {
-        List<String> stateNames = new ArrayList<>(mapOfLocationsByState.keySet());
+        List<String> stateNames = new ArrayList<>(vm.getMapOfLocationsByState().keySet());
         Collections.sort(stateNames);
         stateNames.add(0, Constants.SELECT_STATE);
 
@@ -362,5 +365,4 @@ public class LocationManualSelectionFragment extends Fragment implements Adapter
             Log.d(TAG, "req: getCountryPopulation " + response);
         });
     }
-
 }

--- a/app/src/main/java/com/nsc/covidscore/MainActivity.java
+++ b/app/src/main/java/com/nsc/covidscore/MainActivity.java
@@ -126,7 +126,6 @@ public class MainActivity extends FragmentActivity implements RiskDetailPageFrag
         bundle.putString(Constants.TOTAL_STATE, lastSavedCovidSnapshot.getStateTotalPopulation().toString());
         bundle.putString(Constants.TOTAL_COUNTRY, lastSavedCovidSnapshot.getCountryTotalPopulation().toString());
         bundle.putSerializable(Constants.RISK_MAP,riskMap);
-        bundle.putSerializable(Constants.LOCATIONS_MAP_BY_STATE, mapOfLocationsByState);
 
         // TODO: Save current CovidSnapshot and Location to this bundle
 

--- a/app/src/main/java/com/nsc/covidscore/MainActivity.java
+++ b/app/src/main/java/com/nsc/covidscore/MainActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.ViewModelProvider;
 
@@ -25,7 +26,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-public class MainActivity extends FragmentActivity {
+public class MainActivity extends FragmentActivity implements RiskDetailPageFragment.OnSelectLocationButtonListener {
     private static final String TAG = MainActivity.class.getSimpleName();
     private HashMap<String, List<Location>> mapOfLocationsByState = new HashMap<>();
     private HashMap<Integer, Location> mapOfLocationsById = new HashMap<>();
@@ -38,6 +39,15 @@ public class MainActivity extends FragmentActivity {
     private RequestSingleton requestManager;
 
     private Context context;
+
+    @Override
+    public void onAttachFragment(@NonNull Fragment fragment) {
+        super.onAttachFragment(fragment);
+        if (fragment instanceof  RiskDetailPageFragment) {
+            RiskDetailPageFragment riskDetailPageFragment = (RiskDetailPageFragment) fragment;
+            riskDetailPageFragment.setOnSelectLocationButtonListener(this);
+        }
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -136,8 +146,10 @@ public class MainActivity extends FragmentActivity {
         locationManualSelectionFragment.setArguments(bundle);
 
         // Add the fragment to the 'fragment_container' FrameLayout
-        getSupportFragmentManager().beginTransaction()
-                .add(R.id.fragContainer, locationManualSelectionFragment, Constants.FRAGMENT_LMSF).commit();
+        getSupportFragmentManager()
+                .beginTransaction()
+                .replace(R.id.fragContainer, locationManualSelectionFragment, Constants.FRAGMENT_LMSF)
+                .addToBackStack(null).commit();
     }
 
     @Override
@@ -242,4 +254,9 @@ public class MainActivity extends FragmentActivity {
         }
     }
 
+
+    @Override
+    public void onLocationButtonClicked() {
+        openLocationSelectionFragment();
+    }
 }

--- a/app/src/main/java/com/nsc/covidscore/RiskDetailPageFragment.java
+++ b/app/src/main/java/com/nsc/covidscore/RiskDetailPageFragment.java
@@ -12,19 +12,13 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentTransaction;
-
-import com.nsc.covidscore.room.Location;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Objects;
 
 
 public class RiskDetailPageFragment extends Fragment {
     private static final String TAG = RiskDetailPageFragment.class.getSimpleName();
-    private HashMap<String, List<Location>> mapOfLocationsByState = new HashMap<>();
-    private HashMap<Integer, List<Location>> mapOfLocationsById = new HashMap<>();
     private String currentLocation;
     private String activeCounty;
     private String activeState;
@@ -56,6 +50,8 @@ public class RiskDetailPageFragment extends Fragment {
     private String[] groupSizesArray;
     Resources res;
 
+    OnSelectLocationButtonListener callback;
+
     public RiskDetailPageFragment() {
         // Required empty public constructor
     }
@@ -75,13 +71,6 @@ public class RiskDetailPageFragment extends Fragment {
         View v = inflater.inflate(R.layout.fragment_risk_detail, container, false);
         super.onCreate(savedInstanceState);
         Bundle bundle = getArguments();
-
-        if (bundle != null) {
-            // noinspection unchecked
-            mapOfLocationsByState = (HashMap<String, List<Location>>) bundle.getSerializable(Constants.LOCATIONS_MAP_BY_STATE);
-            mapOfLocationsById = (HashMap<Integer, List<Location>>) bundle.getSerializable(Constants.LOCATIONS_MAP_BY_ID);
-            Log.i(TAG, "onCreateView: Bundle received from MainActivity");
-        }
 
         Log.d(TAG, "onCreateView invoked");
         return v;
@@ -117,22 +106,7 @@ public class RiskDetailPageFragment extends Fragment {
 
 
         Button btnSelectNewLocation = v.findViewById(R.id.select_location_btn);
-        btnSelectNewLocation.setOnClickListener(v1 -> {
-            FragmentTransaction transaction = getParentFragmentManager().beginTransaction();
-            LocationManualSelectionFragment locationManualSelectionFragment = new LocationManualSelectionFragment();
-
-            Bundle bundle = new Bundle();
-            bundle.putSerializable("allLocationsMapByState", mapOfLocationsByState);
-            bundle.putSerializable("allLocationsMapById", mapOfLocationsById);
-
-            locationManualSelectionFragment.setArguments(bundle);
-
-            transaction.replace(R.id.fragContainer, locationManualSelectionFragment, Constants.FRAGMENT_LMSF);
-            transaction.addToBackStack(null);
-
-            // Commit the transaction
-            transaction.commit();
-        });
+        btnSelectNewLocation.setOnClickListener(v1 -> callback.onLocationButtonClicked());
 
         Bundle bundle = getArguments();
 
@@ -189,5 +163,13 @@ public class RiskDetailPageFragment extends Fragment {
     @Override
     public void onDestroy() {
         super.onDestroy();
+    }
+
+    public void setOnSelectLocationButtonListener(OnSelectLocationButtonListener callback) {
+        this.callback = callback;
+    }
+
+    public interface OnSelectLocationButtonListener {
+        public void onLocationButtonClicked();
     }
 }

--- a/app/src/main/java/com/nsc/covidscore/room/CovidSnapshotWithLocationRepository.java
+++ b/app/src/main/java/com/nsc/covidscore/room/CovidSnapshotWithLocationRepository.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import androidx.lifecycle.LiveData;
 
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.List;
 
 public class CovidSnapshotWithLocationRepository {

--- a/app/src/main/java/com/nsc/covidscore/room/CovidSnapshotWithLocationViewModel.java
+++ b/app/src/main/java/com/nsc/covidscore/room/CovidSnapshotWithLocationViewModel.java
@@ -1,23 +1,49 @@
 package com.nsc.covidscore.room;
 
 import android.app.Application;
+import android.content.Context;
+import android.content.res.AssetManager;
 
 import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 
+import com.nsc.covidscore.Constants;
 import com.nsc.covidscore.room.CovidSnapshot;
 import com.nsc.covidscore.room.CovidSnapshotWithLocationRepository;
 import com.nsc.covidscore.room.Location;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public class CovidSnapshotWithLocationViewModel extends AndroidViewModel {
 
     private CovidSnapshotWithLocationRepository repo;
+    private Context context;
+
+
+    private HashMap<String, List<Location>> mapOfLocationsByState = new HashMap<>();
+    private HashMap<Integer, Location> mapOfLocationsById = new HashMap<>();
 
     public CovidSnapshotWithLocationViewModel(Application application) {
         super(application);
         repo = new CovidSnapshotWithLocationRepository(application);
+        context = application.getApplicationContext();
+        fillLocationsMaps();
+    }
+
+    public HashMap<String, List<Location>> getMapOfLocationsByState() {
+        return mapOfLocationsByState;
+    }
+
+    public HashMap<Integer, Location> getMapOfLocationsById() {
+        return mapOfLocationsById;
     }
 
     public void insertCovidSnapshot(CovidSnapshot covidSnapshot) {
@@ -30,5 +56,41 @@ public class CovidSnapshotWithLocationViewModel extends AndroidViewModel {
 //    public LiveData<CovidSnapshot> getLatestCovidSnapshotByLocation(Location location) { return repo.getLatestCovidSnapshotByLocation(location); }
 
     public LiveData<CovidSnapshot> getLatestCovidSnapshot() { return repo.getLatestSnapshot(); }
+
+    private void fillLocationsMaps() {
+        String jsonString;
+        JSONArray jsonArray;
+        AssetManager assetManager = context.getAssets();
+        try {
+            InputStream inputStream = assetManager.open(Constants.LOCATION_FILENAME);
+            byte[] buffer = new byte[inputStream.available()];
+            int read = inputStream.read(buffer);
+            if (read == -1) {
+                inputStream.close();
+            }
+            jsonString = new String(buffer, StandardCharsets.UTF_8);
+            jsonArray = new JSONArray(jsonString);
+            for (int i = 1; i < jsonArray.length(); i++) {
+                JSONArray currentArray = jsonArray.getJSONArray(i);
+                Integer locationId = currentArray.getInt(0);
+                // split county and state names
+                String[] nameArray = currentArray.getString(1).split(Constants.COMMA);
+                String countyName = nameArray[0].trim();
+                String stateName = nameArray[1].trim();
+                String stateFips = currentArray.getString(2);
+                String countyFips = currentArray.getString(3);
+                Location countyInState = new Location(locationId, countyName, stateName, countyFips, stateFips);
+
+                mapOfLocationsById.put(locationId, countyInState);
+                if (mapOfLocationsByState.get(stateName) == null) {
+                    mapOfLocationsByState.put(stateName, new ArrayList<>());
+                }
+                mapOfLocationsByState.get(stateName).add(countyInState);
+            }
+
+        } catch (IOException | JSONException exception) {
+            exception.printStackTrace();
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary
No issue attached to this

This MR does the following:
* Adds interfaces for fragment to fragment communication so we're not sending intents directly from one fragment to another. I followed [this page of the Android documentation](https://developer.android.com/training/basics/fragments/communicating) to implement this
* Fixes a bug where clicking the square android button would cause the app to crash (looked to happen after the onStop() lifecycle method)
  * Moves the `fillLocationsMap()` function from `MainActivity.java` to the ViewModel. Any time we need `mapOfLocationsByState` or `mapOfLocationsById`, we call getters in the ViewModel

I didn't add any new tests, but these changes do slightly increase our code and complexity coverage.

## Checklist
- [ ] New tests added to account for changes in this MR
- [x] All tests passing locally
- [x] All tests passing on CircleCI
- [x] Assigned at least 2 reviewers
