### PR TITLE
Yaholl/card views

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,6 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="testRunner" value="PLATFORM" />
+        <option name="disableWrapperSourceDistributionNotification" value="true" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="1.8" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,7 @@ android {
 }
 
 dependencies {
+    implementation "androidx.cardview:cardview:1.0.0"
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation "androidx.room:room-runtime:2.2.5"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'

--- a/app/src/androidTest/java/com/nsc/covidscore/MainActivityTest.java
+++ b/app/src/androidTest/java/com/nsc/covidscore/MainActivityTest.java
@@ -15,6 +15,7 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.action.ViewActions.swipeUp;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.*;
 import static org.hamcrest.Matchers.allOf;
@@ -62,7 +63,7 @@ public class MainActivityTest {
     @Test
     public void t3_canSelectNewLocation() throws InterruptedException {
         Thread.sleep(1000);
-        onView(withId(R.id.select_location_btn)).perform(scrollTo());
+        onView(withId(R.id.fullscreen_content_controls)).perform(swipeUp());
         onView(withId(R.id.select_location_btn)).perform(click());
 
         // click submit

--- a/app/src/androidTest/java/com/nsc/covidscore/MainActivityTest.java
+++ b/app/src/androidTest/java/com/nsc/covidscore/MainActivityTest.java
@@ -15,6 +15,7 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.action.ViewActions.swipeDown;
 import static androidx.test.espresso.action.ViewActions.swipeUp;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.*;

--- a/app/src/androidTest/java/com/nsc/covidscore/MainActivityTest.java
+++ b/app/src/androidTest/java/com/nsc/covidscore/MainActivityTest.java
@@ -63,7 +63,7 @@ public class MainActivityTest {
     @Test
     public void t3_canSelectNewLocation() throws InterruptedException {
         Thread.sleep(1000);
-        onView(withId(R.id.fullscreen_content_controls)).perform(swipeUp());
+        onView(withId(R.id.fullscreen_content_controls)).perform(swipeDown());
         onView(withId(R.id.select_location_btn)).perform(click());
 
         // click submit

--- a/app/src/androidTest/java/com/nsc/covidscore/MainActivityTest.java
+++ b/app/src/androidTest/java/com/nsc/covidscore/MainActivityTest.java
@@ -14,6 +14,7 @@ import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.*;
 import static org.hamcrest.Matchers.allOf;
@@ -61,6 +62,7 @@ public class MainActivityTest {
     @Test
     public void t3_canSelectNewLocation() throws InterruptedException {
         Thread.sleep(1000);
+        onView(withId(R.id.select_location_btn)).perform(scrollTo());
         onView(withId(R.id.select_location_btn)).perform(click());
 
         // click submit

--- a/app/src/main/java/com/nsc/covidscore/Constants.java
+++ b/app/src/main/java/com/nsc/covidscore/Constants.java
@@ -11,6 +11,7 @@ public class Constants {
     public static final String DISTRICT_OF_COLUMBIA = "district of columbia";
     public static final String LOCATION_FIPS_COUNTY_STRING = " county, ";
     public static final String POPULATION = "population";
+    public static final String UPDATED = "Updated at ";
     public static final String PROVINCE = "province";
     public static final String STATE = "state";
     public static final String STATE_POPULATION = "statePopulation";
@@ -21,12 +22,9 @@ public class Constants {
     public static final String COVID_SNAPSHOT_ID = "covidSnapshotId";
     public static final String CURRENT_LOCATION = "currentLocation";
     public static final String ERROR_STATE_COUNTY = "The State/County combination couldn't be found";
-    public static final String LAST_UPDATED_LOCATION = "lastUpdatedLocation";
-    public static final String LAST_UPDATED_SNAPSHOT = "lastUpdatedSnapshot";
+    public static final String LAST_UPDATED = "lastUpdated";
     public static final String LOCATION_ID_FK = "locationIdFK";
     public static final String LOCATION_ID_PK = "locationIdPK";
-    public static final String LOCATIONS_MAP_BY_STATE = "allLocationsMapByState";
-    public static final String LOCATIONS_MAP_BY_ID = "allLocationsMapById";
     public static final String RISK_MAP = "riskMap";
     public static final String TOTAL_COUNTY = "totalCounty";
     public static final String TOTAL_COUNTRY = "totalCountry";

--- a/app/src/main/java/com/nsc/covidscore/LocationManualSelectionFragment.java
+++ b/app/src/main/java/com/nsc/covidscore/LocationManualSelectionFragment.java
@@ -1,6 +1,7 @@
 package com.nsc.covidscore;
 
 import android.content.Context;
+import android.content.res.AssetManager;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -25,10 +26,13 @@ import com.nsc.covidscore.room.CovidSnapshot;
 import com.nsc.covidscore.room.CovidSnapshotWithLocationViewModel;
 import com.nsc.covidscore.room.Location;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -45,7 +49,6 @@ public class LocationManualSelectionFragment extends Fragment implements Adapter
     private CovidSnapshotWithLocationViewModel vm;
     private TextView loadingTextView;
 
-    private HashMap<String, List<Location>> mapOfLocationsByState = new HashMap<>();
     private List<Location> countyLocations = new ArrayList<>();
     private Spinner state_spinner;
     private Spinner county_spinner;
@@ -86,7 +89,7 @@ public class LocationManualSelectionFragment extends Fragment implements Adapter
 
         if (bundle != null) {
             // noinspection unchecked
-            mapOfLocationsByState = (HashMap<String, List<Location>>) bundle.getSerializable(Constants.LOCATIONS_MAP_BY_STATE);
+//            mapOfLocationsByState = (HashMap<String, List<Location>>) bundle.getSerializable(Constants.LOCATIONS_MAP_BY_STATE);
             Log.i(TAG, "onCreateView: Bundle received from MainActivity");
         }
 
@@ -183,7 +186,7 @@ public class LocationManualSelectionFragment extends Fragment implements Adapter
                 Log.i(TAG, "onCreateView - mutableSelectedState: STATE SELECTED " + stateSelected);
 
                 // get counties
-                countyLocations = mapOfLocationsByState.get(stateSelected);
+                countyLocations = vm.getMapOfLocationsByState().get(stateSelected);
                 List<String> countyNamesInner = countyLocations.stream().map(Location::getCounty).sorted().collect(Collectors.toList());
                 countyNamesInner.add(0, Constants.SELECT_COUNTY);
 
@@ -218,7 +221,7 @@ public class LocationManualSelectionFragment extends Fragment implements Adapter
     }
 
     public void setInitialSpinners(View v) {
-        List<String> stateNames = new ArrayList<>(mapOfLocationsByState.keySet());
+        List<String> stateNames = new ArrayList<>(vm.getMapOfLocationsByState().keySet());
         Collections.sort(stateNames);
         stateNames.add(0, Constants.SELECT_STATE);
 
@@ -362,5 +365,4 @@ public class LocationManualSelectionFragment extends Fragment implements Adapter
             Log.d(TAG, "req: getCountryPopulation " + response);
         });
     }
-
 }

--- a/app/src/main/java/com/nsc/covidscore/MainActivity.java
+++ b/app/src/main/java/com/nsc/covidscore/MainActivity.java
@@ -24,6 +24,7 @@ import org.json.JSONException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -123,7 +124,8 @@ public class MainActivity extends FragmentActivity implements RiskDetailPageFrag
         bundle.putString(Constants.TOTAL_COUNTRY, lastSavedCovidSnapshot.getCountryTotalPopulation().toString());
         bundle.putSerializable(Constants.RISK_MAP,riskMap);
 
-        // TODO: Save current CovidSnapshot and Location to this bundle
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        bundle.putString(Constants.LAST_UPDATED, sdf.format(lastSavedCovidSnapshot.getLastUpdated().getTime()));
 
         // In case this activity was started with special instructions from an
         // Intent, pass the Intent's extras to the fragment as arguments
@@ -136,7 +138,7 @@ public class MainActivity extends FragmentActivity implements RiskDetailPageFrag
 
     public void openNewRiskDetailPageFragment(MutableLiveData<CovidSnapshot> mcs, Location selectedLocation) {
         Log.i(TAG, "onViewCreated - btnNavRiskDetail - selectedLocation filled: " + selectedLocation.toString());
-        // TODO: Save to Room, set Location ID on snapshot
+
         LocationManualSelectionFragment lmsFragment = (LocationManualSelectionFragment) getSupportFragmentManager().findFragmentByTag(Constants.FRAGMENT_LMSF);
         if (lmsFragment != null) {
             lmsFragment.saveSnapshotToRoom(mcs.getValue(), selectedLocation);
@@ -163,6 +165,8 @@ public class MainActivity extends FragmentActivity implements RiskDetailPageFrag
         bundle.putString(Constants.TOTAL_STATE, snapshot.getStateTotalPopulation().toString());
         bundle.putString(Constants.TOTAL_COUNTRY, snapshot.getCountryTotalPopulation().toString());
         bundle.putSerializable(Constants.RISK_MAP,riskMap);
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        bundle.putString(Constants.LAST_UPDATED, sdf.format(lastSavedCovidSnapshot.getLastUpdated().getTime()));
         riskDetailPageFragment.setArguments(bundle);
         transaction.replace(R.id.fragContainer, riskDetailPageFragment, Constants.FRAGMENT_RDPF);
         transaction.addToBackStack(null);

--- a/app/src/main/java/com/nsc/covidscore/MainActivity.java
+++ b/app/src/main/java/com/nsc/covidscore/MainActivity.java
@@ -126,7 +126,6 @@ public class MainActivity extends FragmentActivity implements RiskDetailPageFrag
         bundle.putString(Constants.TOTAL_STATE, lastSavedCovidSnapshot.getStateTotalPopulation().toString());
         bundle.putString(Constants.TOTAL_COUNTRY, lastSavedCovidSnapshot.getCountryTotalPopulation().toString());
         bundle.putSerializable(Constants.RISK_MAP,riskMap);
-        bundle.putSerializable(Constants.LOCATIONS_MAP_BY_STATE, mapOfLocationsByState);
 
         // TODO: Save current CovidSnapshot and Location to this bundle
 

--- a/app/src/main/java/com/nsc/covidscore/MainActivity.java
+++ b/app/src/main/java/com/nsc/covidscore/MainActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.ViewModelProvider;
 
@@ -25,7 +26,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-public class MainActivity extends FragmentActivity {
+public class MainActivity extends FragmentActivity implements RiskDetailPageFragment.OnSelectLocationButtonListener {
     private static final String TAG = MainActivity.class.getSimpleName();
     private HashMap<String, List<Location>> mapOfLocationsByState = new HashMap<>();
     private HashMap<Integer, Location> mapOfLocationsById = new HashMap<>();
@@ -38,6 +39,15 @@ public class MainActivity extends FragmentActivity {
     private RequestSingleton requestManager;
 
     private Context context;
+
+    @Override
+    public void onAttachFragment(@NonNull Fragment fragment) {
+        super.onAttachFragment(fragment);
+        if (fragment instanceof  RiskDetailPageFragment) {
+            RiskDetailPageFragment riskDetailPageFragment = (RiskDetailPageFragment) fragment;
+            riskDetailPageFragment.setOnSelectLocationButtonListener(this);
+        }
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -136,8 +146,10 @@ public class MainActivity extends FragmentActivity {
         locationManualSelectionFragment.setArguments(bundle);
 
         // Add the fragment to the 'fragment_container' FrameLayout
-        getSupportFragmentManager().beginTransaction()
-                .add(R.id.fragContainer, locationManualSelectionFragment, Constants.FRAGMENT_LMSF).commit();
+        getSupportFragmentManager()
+                .beginTransaction()
+                .replace(R.id.fragContainer, locationManualSelectionFragment, Constants.FRAGMENT_LMSF)
+                .addToBackStack(null).commit();
     }
 
     @Override
@@ -242,4 +254,9 @@ public class MainActivity extends FragmentActivity {
         }
     }
 
+
+    @Override
+    public void onLocationButtonClicked() {
+        openLocationSelectionFragment();
+    }
 }

--- a/app/src/main/java/com/nsc/covidscore/RiskDetailPageFragment.java
+++ b/app/src/main/java/com/nsc/covidscore/RiskDetailPageFragment.java
@@ -7,6 +7,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.ImageButton;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -27,6 +28,7 @@ public class RiskDetailPageFragment extends Fragment {
     private String totalState;
     private String totalCountry;
     private HashMap<Integer, Double> riskMap;
+    private String lastUpdated;
 
     private TextView currentLocationV;
     private TextView activeCountyV;
@@ -46,6 +48,8 @@ public class RiskDetailPageFragment extends Fragment {
     private TextView riskGroup3;
     private TextView riskGroup4;
     private TextView riskGroup5;
+
+    private TextView lastUpdatedV;
 
     private String[] groupSizesArray;
     Resources res;
@@ -102,11 +106,13 @@ public class RiskDetailPageFragment extends Fragment {
         riskGroup4 = v.findViewById(R.id.fourthGroup);
         riskGroup5 = v.findViewById(R.id.fifthGroup);
 
+        lastUpdatedV = v.findViewById(R.id.lastUpdatedTextView);
+
         res = Objects.requireNonNull(getActivity()).getResources();
         groupSizesArray = res.getStringArray(R.array.group_sizes);
 
 
-        Button btnSelectNewLocation = v.findViewById(R.id.select_location_btn);
+        ImageButton btnSelectNewLocation = v.findViewById(R.id.select_location_btn);
         btnSelectNewLocation.setOnClickListener(v1 -> callback.onLocationButtonClicked());
 
         Bundle bundle = getArguments();
@@ -123,6 +129,10 @@ public class RiskDetailPageFragment extends Fragment {
             totalCountry = bundle.getString(Constants.TOTAL_COUNTRY);
 
             riskMap = (HashMap<Integer, Double>) bundle.getSerializable(Constants.RISK_MAP);
+
+            StringBuilder lastUpdatedSB = new StringBuilder(Constants.UPDATED)
+                    .append(bundle.getString(Constants.LAST_UPDATED));
+            lastUpdated = lastUpdatedSB.toString();
 
             currentLocationV.setText(currentLocation);
 
@@ -145,6 +155,8 @@ public class RiskDetailPageFragment extends Fragment {
             riskGroup3.setText(String.format(res.getString(R.string.risk), riskMap.get(Constants.GROUP_SIZES[2])));
             riskGroup4.setText(String.format(res.getString(R.string.risk), riskMap.get(Constants.GROUP_SIZES[3])));
             riskGroup5.setText(String.format(res.getString(R.string.risk), riskMap.get(Constants.GROUP_SIZES[4])));
+
+            lastUpdatedV.setText(lastUpdated);
 
             Log.i(TAG, "onCreateView: Bundle received from LocationManualSelectionFragment");
         }

--- a/app/src/main/java/com/nsc/covidscore/RiskDetailPageFragment.java
+++ b/app/src/main/java/com/nsc/covidscore/RiskDetailPageFragment.java
@@ -79,6 +79,7 @@ public class RiskDetailPageFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View v, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(v, savedInstanceState);
+
         currentLocationV = v.findViewById(R.id.currentLocation);
 
         activeCountyV = v.findViewById(R.id.activeCounty);

--- a/app/src/main/java/com/nsc/covidscore/RiskDetailPageFragment.java
+++ b/app/src/main/java/com/nsc/covidscore/RiskDetailPageFragment.java
@@ -12,19 +12,13 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentTransaction;
-
-import com.nsc.covidscore.room.Location;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Objects;
 
 
 public class RiskDetailPageFragment extends Fragment {
     private static final String TAG = RiskDetailPageFragment.class.getSimpleName();
-    private HashMap<String, List<Location>> mapOfLocationsByState = new HashMap<>();
-    private HashMap<Integer, List<Location>> mapOfLocationsById = new HashMap<>();
     private String currentLocation;
     private String activeCounty;
     private String activeState;
@@ -56,6 +50,8 @@ public class RiskDetailPageFragment extends Fragment {
     private String[] groupSizesArray;
     Resources res;
 
+    OnSelectLocationButtonListener callback;
+
     public RiskDetailPageFragment() {
         // Required empty public constructor
     }
@@ -75,13 +71,6 @@ public class RiskDetailPageFragment extends Fragment {
         View v = inflater.inflate(R.layout.fragment_risk_detail, container, false);
         super.onCreate(savedInstanceState);
         Bundle bundle = getArguments();
-
-        if (bundle != null) {
-            // noinspection unchecked
-            mapOfLocationsByState = (HashMap<String, List<Location>>) bundle.getSerializable(Constants.LOCATIONS_MAP_BY_STATE);
-            mapOfLocationsById = (HashMap<Integer, List<Location>>) bundle.getSerializable(Constants.LOCATIONS_MAP_BY_ID);
-            Log.i(TAG, "onCreateView: Bundle received from MainActivity");
-        }
 
         Log.d(TAG, "onCreateView invoked");
         return v;
@@ -117,22 +106,7 @@ public class RiskDetailPageFragment extends Fragment {
 
 
         Button btnSelectNewLocation = v.findViewById(R.id.select_location_btn);
-        btnSelectNewLocation.setOnClickListener(v1 -> {
-            FragmentTransaction transaction = getParentFragmentManager().beginTransaction();
-            LocationManualSelectionFragment locationManualSelectionFragment = new LocationManualSelectionFragment();
-
-            Bundle bundle = new Bundle();
-            bundle.putSerializable("allLocationsMapByState", mapOfLocationsByState);
-            bundle.putSerializable("allLocationsMapById", mapOfLocationsById);
-
-            locationManualSelectionFragment.setArguments(bundle);
-
-            transaction.replace(R.id.fragContainer, locationManualSelectionFragment, Constants.FRAGMENT_LMSF);
-            transaction.addToBackStack(null);
-
-            // Commit the transaction
-            transaction.commit();
-        });
+        btnSelectNewLocation.setOnClickListener(v1 -> callback.onLocationButtonClicked());
 
         Bundle bundle = getArguments();
 
@@ -189,5 +163,13 @@ public class RiskDetailPageFragment extends Fragment {
     @Override
     public void onDestroy() {
         super.onDestroy();
+    }
+
+    public void setOnSelectLocationButtonListener(OnSelectLocationButtonListener callback) {
+        this.callback = callback;
+    }
+
+    public interface OnSelectLocationButtonListener {
+        public void onLocationButtonClicked();
     }
 }

--- a/app/src/main/java/com/nsc/covidscore/room/CovidSnapshotWithLocationRepository.java
+++ b/app/src/main/java/com/nsc/covidscore/room/CovidSnapshotWithLocationRepository.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import androidx.lifecycle.LiveData;
 
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.List;
 
 public class CovidSnapshotWithLocationRepository {

--- a/app/src/main/java/com/nsc/covidscore/room/CovidSnapshotWithLocationViewModel.java
+++ b/app/src/main/java/com/nsc/covidscore/room/CovidSnapshotWithLocationViewModel.java
@@ -1,23 +1,49 @@
 package com.nsc.covidscore.room;
 
 import android.app.Application;
+import android.content.Context;
+import android.content.res.AssetManager;
 
 import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 
+import com.nsc.covidscore.Constants;
 import com.nsc.covidscore.room.CovidSnapshot;
 import com.nsc.covidscore.room.CovidSnapshotWithLocationRepository;
 import com.nsc.covidscore.room.Location;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public class CovidSnapshotWithLocationViewModel extends AndroidViewModel {
 
     private CovidSnapshotWithLocationRepository repo;
+    private Context context;
+
+
+    private HashMap<String, List<Location>> mapOfLocationsByState = new HashMap<>();
+    private HashMap<Integer, Location> mapOfLocationsById = new HashMap<>();
 
     public CovidSnapshotWithLocationViewModel(Application application) {
         super(application);
         repo = new CovidSnapshotWithLocationRepository(application);
+        context = application.getApplicationContext();
+        fillLocationsMaps();
+    }
+
+    public HashMap<String, List<Location>> getMapOfLocationsByState() {
+        return mapOfLocationsByState;
+    }
+
+    public HashMap<Integer, Location> getMapOfLocationsById() {
+        return mapOfLocationsById;
     }
 
     public void insertCovidSnapshot(CovidSnapshot covidSnapshot) {
@@ -30,5 +56,41 @@ public class CovidSnapshotWithLocationViewModel extends AndroidViewModel {
 //    public LiveData<CovidSnapshot> getLatestCovidSnapshotByLocation(Location location) { return repo.getLatestCovidSnapshotByLocation(location); }
 
     public LiveData<CovidSnapshot> getLatestCovidSnapshot() { return repo.getLatestSnapshot(); }
+
+    private void fillLocationsMaps() {
+        String jsonString;
+        JSONArray jsonArray;
+        AssetManager assetManager = context.getAssets();
+        try {
+            InputStream inputStream = assetManager.open(Constants.LOCATION_FILENAME);
+            byte[] buffer = new byte[inputStream.available()];
+            int read = inputStream.read(buffer);
+            if (read == -1) {
+                inputStream.close();
+            }
+            jsonString = new String(buffer, StandardCharsets.UTF_8);
+            jsonArray = new JSONArray(jsonString);
+            for (int i = 1; i < jsonArray.length(); i++) {
+                JSONArray currentArray = jsonArray.getJSONArray(i);
+                Integer locationId = currentArray.getInt(0);
+                // split county and state names
+                String[] nameArray = currentArray.getString(1).split(Constants.COMMA);
+                String countyName = nameArray[0].trim();
+                String stateName = nameArray[1].trim();
+                String stateFips = currentArray.getString(2);
+                String countyFips = currentArray.getString(3);
+                Location countyInState = new Location(locationId, countyName, stateName, countyFips, stateFips);
+
+                mapOfLocationsById.put(locationId, countyInState);
+                if (mapOfLocationsByState.get(stateName) == null) {
+                    mapOfLocationsByState.put(stateName, new ArrayList<>());
+                }
+                mapOfLocationsByState.get(stateName).add(countyInState);
+            }
+
+        } catch (IOException | JSONException exception) {
+            exception.printStackTrace();
+        }
+    }
 }
 

--- a/app/src/main/java/com/nsc/covidscore/room/Location.java
+++ b/app/src/main/java/com/nsc/covidscore/room/Location.java
@@ -53,7 +53,6 @@ public class Location implements Serializable {
     private Calendar lastUpdated;
     public Calendar getLastUpdated() { return lastUpdated; }
     public void setLastUpdated(Calendar lastUpdated) {
-        propertyChangeSupport.firePropertyChange(Constants.LAST_UPDATED_LOCATION, this.lastUpdated, lastUpdated);
         this.lastUpdated = lastUpdated;
     }
 

--- a/app/src/main/res/drawable/ic_edit_location.xml
+++ b/app/src/main/res/drawable/ic_edit_location.xml
@@ -1,0 +1,5 @@
+<vector android:height="50dp" android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="50dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C8.14,2 5,5.14 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.86 -3.14,-7 -7,-7zM10.44,12L9,12v-1.44l3.35,-3.34 1.43,1.43L10.44,12zM14.89,7.55l-0.7,0.7 -1.44,-1.44 0.7,-0.7c0.15,-0.15 0.39,-0.15 0.54,0l0.9,0.9c0.15,0.15 0.15,0.39 0,0.54z"/>
+</vector>

--- a/app/src/main/res/layout/current_cases_detail.xml
+++ b/app/src/main/res/layout/current_cases_detail.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="20dp"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="@android:color/transparent">
+
+    <TextView
+        android:id="@+id/labelCurrentLocation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/std_text_size"
+        android:text="@string/current_location"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/currentLocation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:textSize="@dimen/std_text_size"
+        android:textStyle="bold"
+        app:layout_constraintStart_toEndOf="@id/labelCurrentLocation"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/labelActiveCounty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textSize="@dimen/std_text_size"
+        android:text="@string/active_county"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/labelCurrentLocation" />
+
+    <TextView
+        android:id="@+id/activeCounty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:textSize="@dimen/std_text_size"
+        app:layout_constraintStart_toEndOf="@id/labelActiveCounty"
+        app:layout_constraintTop_toTopOf="@id/labelActiveCounty" />
+
+    <TextView
+        android:id="@+id/labelActiveState"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textSize="@dimen/std_text_size"
+        android:text="@string/active_state"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/labelActiveCounty" />
+
+    <TextView
+        android:id="@+id/activeState"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:textSize="@dimen/std_text_size"
+        app:layout_constraintStart_toEndOf="@id/labelActiveState"
+        app:layout_constraintTop_toTopOf="@id/labelActiveState" />
+
+    <TextView
+        android:id="@+id/labelActiveCountry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textSize="@dimen/std_text_size"
+        android:text="@string/active_country"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/labelActiveState" />
+
+    <TextView
+        android:id="@+id/activeUS"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:textSize="@dimen/std_text_size"
+        app:layout_constraintStart_toEndOf="@id/labelActiveCountry"
+        app:layout_constraintTop_toTopOf="@id/labelActiveCountry" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/current_cases_detail.xml
+++ b/app/src/main/res/layout/current_cases_detail.xml
@@ -4,8 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="20dp"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:background="@android:color/transparent">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <TextView
         android:id="@+id/labelCurrentLocation"
@@ -13,6 +12,7 @@
         android:layout_height="wrap_content"
         android:textSize="@dimen/std_text_size"
         android:text="@string/current_location"
+        android:textStyle="bold"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -22,7 +22,6 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:textSize="@dimen/std_text_size"
-        android:textStyle="bold"
         app:layout_constraintStart_toEndOf="@id/labelCurrentLocation"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -30,7 +29,7 @@
         android:id="@+id/labelActiveCounty"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="24dp"
         android:textSize="@dimen/std_text_size"
         android:text="@string/active_county"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_risk_detail.xml
+++ b/app/src/main/res/layout/fragment_risk_detail.xml
@@ -18,286 +18,67 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:padding="10dp">
+            android:layout_height="match_parent">
 
-            <TextView
-                android:id="@+id/labelActiveState"
-                android:layout_width="wrap_content"
+            <androidx.cardview.widget.CardView
+                android:id="@+id/currentCasesCardView"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:textSize="@dimen/std_text_size"
-                android:text="@string/active_state"
+                android:minHeight="40dp"
+                app:cardBackgroundColor="@color/cardBackground"
+                app:cardCornerRadius="10dp"
+                app:cardElevation="4dp"
+                app:barrierMargin="@dimen/text_margin"
+                android:layout_margin="10dp"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/labelActiveCounty" />
+                app:layout_constraintTop_toTopOf="parent">
 
-            <TextView
-                android:id="@+id/labelActiveCountry"
-                android:layout_width="wrap_content"
+                <include layout="@layout/current_cases_detail"/>
+
+            </androidx.cardview.widget.CardView>
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/totalPopsCardView"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:textSize="@dimen/std_text_size"
-                android:text="@string/active_country"
+                android:minHeight="40dp"
+                android:layout_margin="10dp"
+                app:cardBackgroundColor="@color/cardBackground"
+                app:cardCornerRadius="10dp"
+                app:cardElevation="4dp"
+                app:barrierMargin="@dimen/text_margin"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/labelActiveState" />
+                app:layout_constraintTop_toBottomOf="@id/currentCasesCardView">
 
-            <TextView
-                android:id="@+id/labelCurrentLocation"
-                android:layout_width="wrap_content"
+                <include layout="@layout/total_pops_detail"/>
+
+            </androidx.cardview.widget.CardView>
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/riskDisplayCardView"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textSize="@dimen/std_text_size"
-                android:text="@string/current_location"
+                android:minHeight="40dp"
+                android:layout_margin="10dp"
+                app:cardBackgroundColor="@color/cardBackground"
+                app:cardCornerRadius="10dp"
+                app:cardElevation="4dp"
+                app:barrierMargin="@dimen/text_margin"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toBottomOf="@id/totalPopsCardView">
 
-            <TextView
-                android:id="@+id/labelActiveCounty"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:textSize="@dimen/std_text_size"
-                android:text="@string/active_county"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/labelCurrentLocation" />
+                <include layout="@layout/risk_detail"/>
 
-            <TextView
-                android:id="@+id/activeCounty"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:textSize="@dimen/std_text_size"
-                app:layout_constraintStart_toEndOf="@+id/labelActiveCounty"
-                app:layout_constraintTop_toTopOf="@+id/labelActiveCounty" />
-
-            <TextView
-                android:id="@+id/activeState"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:textSize="@dimen/std_text_size"
-                app:layout_constraintStart_toEndOf="@+id/labelActiveState"
-                app:layout_constraintTop_toTopOf="@+id/labelActiveState" />
-
-            <TextView
-                android:id="@+id/activeUS"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:textSize="@dimen/std_text_size"
-                app:layout_constraintStart_toEndOf="@+id/labelActiveCountry"
-                app:layout_constraintTop_toTopOf="@+id/labelActiveCountry" />
-
-            <TextView
-                android:id="@+id/currentLocation"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:textStyle="bold"
-                app:layout_constraintStart_toEndOf="@+id/labelCurrentLocation"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <TextView
-                android:id="@+id/labelTotalCounty"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:textSize="@dimen/std_text_size"
-                android:text="@string/total_county"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/populations" />
-
-            <TextView
-                android:id="@+id/totalCounty"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                app:layout_constraintStart_toEndOf="@+id/labelTotalCounty"
-                app:layout_constraintTop_toTopOf="@+id/labelTotalCounty" />
-
-            <TextView
-                android:id="@+id/labelTotalCountry"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="@string/total_country"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/labelTotalState" />
-
-            <TextView
-                android:id="@+id/totalState"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                app:layout_constraintStart_toEndOf="@+id/labelTotalState"
-                app:layout_constraintTop_toTopOf="@+id/labelTotalState" />
-
-            <TextView
-                android:id="@+id/labelTotalState"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="@string/total_state"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/labelTotalCounty" />
-
-            <TextView
-                android:id="@+id/totalCountry"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                app:layout_constraintStart_toEndOf="@+id/labelTotalCountry"
-                app:layout_constraintTop_toTopOf="@+id/labelTotalCountry" />
-
-            <TextView
-                android:id="@+id/populations"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:textSize="@dimen/std_text_size"
-                android:text="@string/populations"
-                android:textStyle="bold"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/labelActiveCountry" />
-
-            <TextView
-                android:id="@+id/labelRiskDisplay"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:textSize="@dimen/std_text_size"
-                android:text="@string/risk_assessment"
-                android:textStyle="bold"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/labelTotalCountry" />
-
-            <TextView
-                android:id="@+id/labelGroupSize"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:textSize="@dimen/std_text_size"
-                android:text="@string/group_size"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/labelRiskDisplay" />
-
-            <TextView
-                android:id="@+id/labelRiskAmount"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="@dimen/std_text_size"
-                android:text="@string/risk_of_being_exposed_to_covid"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/labelGroupSize" />
-
-            <TextView
-                android:id="@+id/labelFirstGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:text="@string/group"
-                android:textSize="@dimen/std_text_size"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/labelGroupSize" />
-
-            <TextView
-                android:id="@+id/labelSecondGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="@string/group"
-                android:textSize="@dimen/std_text_size"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/labelFirstGroup" />
-
-            <TextView
-                android:id="@+id/labelThirdGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="@string/group"
-                android:textSize="@dimen/std_text_size"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/labelSecondGroup" />
-
-            <TextView
-                android:id="@+id/labelFourthGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="@string/group"
-                android:textSize="@dimen/std_text_size"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/labelThirdGroup" />
-
-            <TextView
-                android:id="@+id/labelFifthGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="@string/group"
-                android:textSize="@dimen/std_text_size"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/labelFourthGroup" />
-
-            <TextView
-                android:id="@+id/firstGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/risk"
-                android:textSize="@dimen/std_text_size"
-                app:layout_constraintEnd_toEndOf="@+id/labelRiskAmount"
-                app:layout_constraintStart_toStartOf="@+id/labelRiskAmount"
-                app:layout_constraintTop_toTopOf="@+id/labelFirstGroup" />
-
-            <TextView
-                android:id="@+id/secondGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="@dimen/std_text_size"
-                android:text="@string/risk"
-                app:layout_constraintEnd_toEndOf="@+id/labelRiskAmount"
-                app:layout_constraintStart_toStartOf="@+id/labelRiskAmount"
-                app:layout_constraintTop_toTopOf="@+id/labelSecondGroup" />
-
-            <TextView
-                android:id="@+id/thirdGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="@dimen/std_text_size"
-                android:text="@string/risk"
-                app:layout_constraintEnd_toEndOf="@+id/labelRiskAmount"
-                app:layout_constraintStart_toStartOf="@+id/labelRiskAmount"
-                app:layout_constraintTop_toTopOf="@+id/labelThirdGroup" />
-
-            <TextView
-                android:id="@+id/fourthGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="@dimen/std_text_size"
-                android:text="@string/risk"
-                app:layout_constraintEnd_toEndOf="@+id/labelRiskAmount"
-                app:layout_constraintStart_toStartOf="@+id/labelRiskAmount"
-                app:layout_constraintTop_toTopOf="@+id/labelFourthGroup" />
-
-            <TextView
-                android:id="@+id/fifthGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="@dimen/std_text_size"
-                android:text="@string/risk"
-                app:layout_constraintEnd_toEndOf="@+id/labelRiskAmount"
-                app:layout_constraintStart_toStartOf="@+id/labelRiskAmount"
-                app:layout_constraintTop_toTopOf="@+id/labelFifthGroup" />
+            </androidx.cardview.widget.CardView>
 
             <Button
                 android:id="@+id/select_location_btn"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="44dp"
                 android:text="@string/select_location"
                 app:layout_constraintEnd_toEndOf="parent"
-                android:gravity="center"
-                app:layout_constraintTop_toBottomOf="@+id/fifthGroup" />
+                android:layout_marginTop="20dp"
+                app:layout_constraintTop_toBottomOf="@id/riskDisplayCardView" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_risk_detail.xml
+++ b/app/src/main/res/layout/fragment_risk_detail.xml
@@ -78,6 +78,7 @@
                 android:text="@string/select_location"
                 app:layout_constraintEnd_toEndOf="parent"
                 android:layout_marginTop="20dp"
+                android:layout_marginEnd="10dp"
                 app:layout_constraintTop_toBottomOf="@id/riskDisplayCardView" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_risk_detail.xml
+++ b/app/src/main/res/layout/fragment_risk_detail.xml
@@ -1,87 +1,111 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:id="@+id/risk_detail_frag"
-    android:background="@color/colorPrimaryLight"
-    android:layout_margin="10dp"
-    tools:context=".RiskDetailPageFragment">
+    android:layout_height="match_parent">
 
-    <LinearLayout
-        android:id="@+id/fullscreen_content_controls"
+    <androidx.core.widget.NestedScrollView
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical"
-        tools:ignore="UselessParent">
+        android:id="@+id/risk_detail_frag"
+        android:background="@color/colorPrimaryLight"
+        android:layout_margin="10dp"
+        tools:context=".RiskDetailPageFragment">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
+            android:id="@+id/fullscreen_content_controls"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            tools:ignore="UselessParent">
 
-            <androidx.cardview.widget.CardView
-                android:id="@+id/currentCasesCardView"
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:minHeight="40dp"
-                app:cardBackgroundColor="@color/cardBackground"
-                app:cardCornerRadius="10dp"
-                app:cardElevation="4dp"
-                app:barrierMargin="@dimen/text_margin"
-                android:layout_margin="10dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
+                android:layout_height="match_parent">
 
-                <include layout="@layout/current_cases_detail"/>
+                <ImageButton
+                    android:id="@+id/select_location_btn"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_edit_location"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:translationZ="10dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    android:layout_marginTop="10dp"
+                    android:layout_marginEnd="10dp"
+                    android:elevation="20dp"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-            </androidx.cardview.widget.CardView>
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/currentCasesCardView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="40dp"
+                    app:cardBackgroundColor="@color/cardBackground"
+                    app:cardCornerRadius="10dp"
+                    app:barrierMargin="@dimen/text_margin"
+                    android:translationZ="0dp"
+                    android:layout_margin="10dp"
+                    android:elevation="10dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
 
-            <androidx.cardview.widget.CardView
-                android:id="@+id/totalPopsCardView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:minHeight="40dp"
-                android:layout_margin="10dp"
-                app:cardBackgroundColor="@color/cardBackground"
-                app:cardCornerRadius="10dp"
-                app:cardElevation="4dp"
-                app:barrierMargin="@dimen/text_margin"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/currentCasesCardView">
+                    <include layout="@layout/current_cases_detail"/>
 
-                <include layout="@layout/total_pops_detail"/>
+                </androidx.cardview.widget.CardView>
 
-            </androidx.cardview.widget.CardView>
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/totalPopsCardView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="40dp"
+                    android:layout_margin="10dp"
+                    app:cardBackgroundColor="@color/cardBackground"
+                    app:cardCornerRadius="10dp"
+                    android:elevation="10dp"
+                    app:barrierMargin="@dimen/text_margin"
+                    android:translationZ="0dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/currentCasesCardView">
 
-            <androidx.cardview.widget.CardView
-                android:id="@+id/riskDisplayCardView"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:minHeight="40dp"
-                android:layout_margin="10dp"
-                app:cardBackgroundColor="@color/cardBackground"
-                app:cardCornerRadius="10dp"
-                app:cardElevation="4dp"
-                app:barrierMargin="@dimen/text_margin"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/totalPopsCardView">
+                    <include layout="@layout/total_pops_detail"/>
 
-                <include layout="@layout/risk_detail"/>
+                </androidx.cardview.widget.CardView>
 
-            </androidx.cardview.widget.CardView>
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/riskDisplayCardView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="40dp"
+                    android:layout_margin="10dp"
+                    app:cardBackgroundColor="@color/cardBackground"
+                    app:cardCornerRadius="10dp"
+                    android:elevation="10dp"
+                    app:barrierMargin="@dimen/text_margin"
+                    android:translationZ="0dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/totalPopsCardView">
 
-            <Button
-                android:id="@+id/select_location_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/select_location"
-                app:layout_constraintEnd_toEndOf="parent"
-                android:layout_marginTop="20dp"
-                android:layout_marginEnd="10dp"
-                app:layout_constraintTop_toBottomOf="@id/riskDisplayCardView" />
+                    <include layout="@layout/risk_detail"/>
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                </androidx.cardview.widget.CardView>
 
-    </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+    <TextView
+        android:id="@+id/lastUpdatedTextView"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:textSize="@dimen/std_text_size"
+        android:background="@color/colorAccentLight"
+        android:paddingVertical="8dp"
+        android:layout_alignParentBottom="true"
+        android:layout_gravity="bottom"/>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/risk_detail.xml
+++ b/app/src/main/res/layout/risk_detail.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="20dp"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+
+    <TextView
+        android:id="@+id/labelRiskDisplay"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/std_text_size"
+        android:text="@string/risk_assessment"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/labelGroupSize"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textSize="@dimen/std_text_size"
+        android:text="@string/group_size"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/labelRiskDisplay" />
+
+    <TextView
+        android:id="@+id/labelRiskAmount"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/std_text_size"
+        android:text="@string/risk_of_being_exposed_to_covid"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/labelGroupSize" />
+
+    <TextView
+        android:id="@+id/labelFirstGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/group"
+        android:textSize="@dimen/std_text_size"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/labelGroupSize" />
+
+    <TextView
+        android:id="@+id/labelSecondGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/group"
+        android:textSize="@dimen/std_text_size"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/labelFirstGroup" />
+
+    <TextView
+        android:id="@+id/labelThirdGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/group"
+        android:textSize="@dimen/std_text_size"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/labelSecondGroup" />
+
+    <TextView
+        android:id="@+id/labelFourthGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/group"
+        android:textSize="@dimen/std_text_size"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/labelThirdGroup" />
+
+    <TextView
+        android:id="@+id/labelFifthGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/group"
+        android:textSize="@dimen/std_text_size"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/labelFourthGroup" />
+
+    <TextView
+        android:id="@+id/firstGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/risk"
+        android:textSize="@dimen/std_text_size"
+        app:layout_constraintEnd_toEndOf="@id/labelRiskAmount"
+        app:layout_constraintStart_toStartOf="@id/labelRiskAmount"
+        app:layout_constraintTop_toTopOf="@id/labelFirstGroup" />
+
+    <TextView
+        android:id="@+id/secondGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/std_text_size"
+        android:text="@string/risk"
+        app:layout_constraintEnd_toEndOf="@id/labelRiskAmount"
+        app:layout_constraintStart_toStartOf="@id/labelRiskAmount"
+        app:layout_constraintTop_toTopOf="@id/labelSecondGroup" />
+
+    <TextView
+        android:id="@+id/thirdGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/std_text_size"
+        android:text="@string/risk"
+        app:layout_constraintEnd_toEndOf="@id/labelRiskAmount"
+        app:layout_constraintStart_toStartOf="@id/labelRiskAmount"
+        app:layout_constraintTop_toTopOf="@id/labelThirdGroup" />
+
+    <TextView
+        android:id="@+id/fourthGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/std_text_size"
+        android:text="@string/risk"
+        app:layout_constraintEnd_toEndOf="@id/labelRiskAmount"
+        app:layout_constraintStart_toStartOf="@id/labelRiskAmount"
+        app:layout_constraintTop_toTopOf="@id/labelFourthGroup" />
+
+    <TextView
+        android:id="@+id/fifthGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/std_text_size"
+        android:text="@string/risk"
+        app:layout_constraintEnd_toEndOf="@id/labelRiskAmount"
+        app:layout_constraintStart_toStartOf="@id/labelRiskAmount"
+        app:layout_constraintTop_toTopOf="@id/labelFifthGroup" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/risk_detail.xml
+++ b/app/src/main/res/layout/risk_detail.xml
@@ -21,7 +21,7 @@
         android:id="@+id/labelGroupSize"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="24dp"
         android:textSize="@dimen/std_text_size"
         android:text="@string/group_size"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/total_pops_detail.xml
+++ b/app/src/main/res/layout/total_pops_detail.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="20dp">
+
+    <TextView
+        android:id="@+id/populations"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:textSize="@dimen/std_text_size"
+        android:text="@string/populations"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/labelTotalCounty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:textSize="@dimen/std_text_size"
+        android:text="@string/total_county"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/populations" />
+
+    <TextView
+        android:id="@+id/totalCounty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:textSize="@dimen/std_text_size"
+        app:layout_constraintStart_toEndOf="@id/labelTotalCounty"
+        app:layout_constraintTop_toTopOf="@id/labelTotalCounty" />
+
+    <TextView
+        android:id="@+id/labelTotalState"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/total_state"
+        android:textSize="@dimen/std_text_size"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/labelTotalCounty" />
+
+    <TextView
+        android:id="@+id/totalState"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:textSize="@dimen/std_text_size"
+        app:layout_constraintStart_toEndOf="@id/labelTotalState"
+        app:layout_constraintTop_toTopOf="@id/labelTotalState" />
+
+    <TextView
+        android:id="@+id/labelTotalCountry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/total_country"
+        android:textSize="@dimen/std_text_size"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/labelTotalState" />
+
+    <TextView
+        android:id="@+id/totalCountry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:textSize="@dimen/std_text_size"
+        app:layout_constraintStart_toEndOf="@id/labelTotalCountry"
+        app:layout_constraintTop_toTopOf="@id/labelTotalCountry" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/total_pops_detail.xml
+++ b/app/src/main/res/layout/total_pops_detail.xml
@@ -10,7 +10,6 @@
         android:id="@+id/populations"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
         android:textSize="@dimen/std_text_size"
         android:text="@string/populations"
         android:textStyle="bold"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
     <color name="colorPrimary">#525174</color>
     <color name="colorPrimaryDark">#348AA7</color>
     <color name="colorPrimaryLight">#DFF8FF</color>
+    <color name="cardBackground">#B9DFF8FF</color>
     <color name="colorAccent">#5DD39E</color>
     <color name="colorAccentLight">#BCE784</color>
     <color name="colorAccentDark">#513B56</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,4 @@
 <resources>
     <dimen name="text_margin">16dp</dimen>
-    <dimen name="std_text_size">15sp</dimen>
+    <dimen name="std_text_size">18sp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="populations">Populations</string>
     <string name="risk_assessment">Risk Assessment</string>
     <string name="group_size">Group Size</string>
-    <string name="risk_of_being_exposed_to_covid">Risk of being exposed to COVID</string>
+    <string name="risk_of_being_exposed_to_covid">Risk of COVID exposure</string>
 
     <string-array name="group_sizes">
         <item>10</item>


### PR DESCRIPTION
## Summary
Closes #12 

MERGE ORDER: #39 , #42 , THEN this one #43

Splits Risk Detail sections into CardViews to improve the look - I was unable to successfully implement either an expanding card view or a draggable one, and since that wasn't really the spec I gave up on that. They're just pretty, but they're organized better, so in the future, it should be easier to change the components we use, if we want.
I also added a footer to the RiskDetailFragment to show when the data was last updated, so that piece of data was added to the bundles being passed

* Splits each detail section into its own layout, to make it more modular
* Changed some colors/styling
* Added footer displaying most recent update of information
* Changed "Select Location" button in RiskDetailFragment to an ImageButton in the top right corner

## Checklist
- [ ] New tests added to account for changes in this MR
- [x] All tests passing locally
- [x] All tests passing on CircleCI
- [x] Assigned at least 2 reviewers
