### PR TITLE
Yaholl/check internet connection

### DIFF
--- a/app/src/androidTest/java/com/nsc/covidscore/MainActivityTest.java
+++ b/app/src/androidTest/java/com/nsc/covidscore/MainActivityTest.java
@@ -4,6 +4,7 @@ import androidx.test.espresso.NoMatchingViewException;
 import androidx.test.espresso.PerformException;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.FixMethodOrder;
 import org.junit.Rule;
@@ -43,6 +44,7 @@ public class MainActivityTest {
                 onData(allOf(is(instanceOf(String.class)), is("California"))).perform(click());
             } catch (NoMatchingViewException | PerformException ex) {
                 // We are in RiskDetailFragment - click select new
+                onView(withId(R.id.activeCounty)).check(matches(not(withText(""))));
                 onView(withId(R.id.select_location_btn)).perform(click());
             }
 
@@ -68,12 +70,6 @@ public class MainActivityTest {
         }
     }
 
-//    @Test
-//    public void t2_canViewCovidStats() {
-//        // inside the RiskDetailPageFragment
-//        onView(withId(R.id.activeCounty)).check(matches(not(withText(""))));
-//    }
-
     @Test
     public void t2_canSelectNewLocation() throws InterruptedException {
         try {
@@ -95,6 +91,7 @@ public class MainActivityTest {
                 onView(withId(R.layout.fragment_location_selection)).check(matches(isDisplayed()));
             } catch (NoMatchingViewException | PerformException ex) {
                 // We are in RiskDetailFragment - click select new
+                onView(withId(R.id.activeCounty)).check(matches(not(withText(""))));
                 onView(withId(R.id.select_location_btn)).perform(click());
             }
             // In New LocationManualSelectionFragment
@@ -142,5 +139,43 @@ public class MainActivityTest {
 //        pressBack();
 //    }
 
+    @Test
+    public void t3_checksInternet() throws InterruptedException {
+        Thread.sleep(8000); // Time for app to load
+        try { // Are we in the LocationManualSelectionFragment?
+            // select state
+            onView(withId(R.id.state_spinner)).perform(click());
+            onData(allOf(is(instanceOf(String.class)), is("California"))).perform(click());
+        } catch (NoMatchingViewException | PerformException ex) {
+            // We are in RiskDetailFragment - click select new
+            onView(withId(R.id.select_location_btn)).perform(click());
+        }
+        // In LocationManualSelectionFragment
 
+        // disable wifi & data
+        InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand("svc wifi disable");
+        InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand("svc data disable");
+
+        // select state
+        onView(withId(R.id.state_spinner)).perform(click());
+        onData(allOf(is(instanceOf(String.class)), is("Washington"))).perform(click());
+
+        // select county
+        onView(withId(R.id.county_spinner)).perform(click());
+        onData(allOf(is(instanceOf(String.class)), is("king"))).perform(click());
+
+        // submit
+        onView(withId(R.id.submit_btn)).perform(click());
+        onView(withId(R.id.loadingTextView)).check(matches(withText(R.string.no_internet)));
+
+        // enable wifi & data
+        InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand("svc wifi enable");
+        InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand("svc data enable");
+
+        Thread.sleep(2000);
+
+        // submit
+        onView(withId(R.id.submit_btn)).perform(click());
+        onView(withId(R.id.loadingTextView)).check(matches(withText(R.string.loading_data)));
+    }
 }

--- a/app/src/androidTest/java/com/nsc/covidscore/MainActivityTest.java
+++ b/app/src/androidTest/java/com/nsc/covidscore/MainActivityTest.java
@@ -1,6 +1,7 @@
 package com.nsc.covidscore;
 
 import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.espresso.PerformException;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -33,8 +34,18 @@ public class MainActivityTest {
             new ActivityScenarioRule<>(MainActivity.class);
 
     @Test
-    public void t1_canSelectLocation() throws InterruptedException {
+    public void t1_canSelectLocationAndViewRisk() throws InterruptedException {
         try {
+            Thread.sleep(8000); // Time for app to load
+            try { // Are we in the LocationManualSelectionFragment?
+                // select state
+                onView(withId(R.id.state_spinner)).perform(click());
+                onData(allOf(is(instanceOf(String.class)), is("California"))).perform(click());
+            } catch (NoMatchingViewException | PerformException ex) {
+                // We are in RiskDetailFragment - click select new
+                onView(withId(R.id.select_location_btn)).perform(click());
+            }
+
             // inside the LocationManualSelectionFragment
 
             // select state
@@ -50,38 +61,86 @@ public class MainActivityTest {
 
             Thread.sleep(5000);
             onView(withId(R.layout.fragment_location_selection)).check(matches(isDisplayed()));
-        } catch (NoMatchingViewException ex) {
+        } catch (NoMatchingViewException | PerformException ex) {
             // pass over this test to avoid crashing, we're in the RiskDetailPageFragment
+            // inside the RiskDetailPageFragment
+            onView(withId(R.id.activeCounty)).check(matches(not(withText(""))));
         }
     }
 
-    @Test
-    public void t2_canViewCovidStats() {
-        // inside the RiskDetailPageFragment
-        onView(withId(R.id.activeCounty)).check(matches(not(withText(""))));
-    }
+//    @Test
+//    public void t2_canViewCovidStats() {
+//        // inside the RiskDetailPageFragment
+//        onView(withId(R.id.activeCounty)).check(matches(not(withText(""))));
+//    }
 
     @Test
-    public void t3_canSelectNewLocation() throws InterruptedException {
-        Thread.sleep(1000);
-        onView(withId(R.id.fullscreen_content_controls)).perform(swipeDown());
-        onView(withId(R.id.select_location_btn)).perform(click());
+    public void t2_canSelectNewLocation() throws InterruptedException {
+        try {
+            Thread.sleep(8000); // Time for the app to load
 
-        // click submit
-        onView(withId(R.id.submit_btn)).perform(click());
-        onView(withId(R.id.loadingTextView)).check(matches(withText("Please pick a state and county")));
+            try { // Are we in the LocationManualSelectionFragment? Get to the RiskDetailFragment
+                // select state
+                onView(withId(R.id.state_spinner)).perform(click());
+                onData(allOf(is(instanceOf(String.class)), is("California"))).perform(click());
 
-        // select state
-        onView(withId(R.id.state_spinner)).perform(click());
-        onData(allOf(is(instanceOf(String.class)), is("Washington"))).perform(click());
+                // select county
+                onView(withId(R.id.county_spinner)).perform(click());
+                onData(allOf(is(instanceOf(String.class)), is("imperial"))).perform(click());
 
-        // select county
-        onView(withId(R.id.county_spinner)).perform(click());
-        onData(allOf(is(instanceOf(String.class)), is("king"))).perform(click());
+                // click submit
+                onView(withId(R.id.submit_btn)).perform(click());
 
-        Thread.sleep(3000);
-        pressBack();
+                Thread.sleep(5000);
+                onView(withId(R.layout.fragment_location_selection)).check(matches(isDisplayed()));
+            } catch (NoMatchingViewException | PerformException ex) {
+                // We are in RiskDetailFragment - click select new
+                onView(withId(R.id.select_location_btn)).perform(click());
+            }
+            // In New LocationManualSelectionFragment
+
+            // click submit
+            onView(withId(R.id.submit_btn)).perform(click());
+            onView(withId(R.id.loadingTextView)).check(matches(withText("Please pick a state and county")));
+
+            // select state
+            onView(withId(R.id.state_spinner)).perform(click());
+            onData(allOf(is(instanceOf(String.class)), is("Washington"))).perform(click());
+
+            // select county
+            onView(withId(R.id.county_spinner)).perform(click());
+            onData(allOf(is(instanceOf(String.class)), is("king"))).perform(click());
+
+            Thread.sleep(3000);
+            pressBack();
+
+        } catch (PerformException | NoMatchingViewException ex) {
+            // we're in the RiskDetailPageFragment
+            onView(withId(R.id.activeCounty)).check(matches(not(withText(""))));
+        }
     }
+//
+//    @Test
+//    public void t3_canSelectNewLocation() throws InterruptedException {
+//        Thread.sleep(1000);
+//        onView(withId(R.id.fullscreen_content_controls)).perform(swipeDown());
+//        onView(withId(R.id.select_location_btn)).perform(click());
+//
+//        // click submit
+//        onView(withId(R.id.submit_btn)).perform(click());
+//        onView(withId(R.id.loadingTextView)).check(matches(withText("Please pick a state and county")));
+//
+//        // select state
+//        onView(withId(R.id.state_spinner)).perform(click());
+//        onData(allOf(is(instanceOf(String.class)), is("Washington"))).perform(click());
+//
+//        // select county
+//        onView(withId(R.id.county_spinner)).perform(click());
+//        onData(allOf(is(instanceOf(String.class)), is("king"))).perform(click());
+//
+//        Thread.sleep(3000);
+//        pressBack();
+//    }
 
 
 }

--- a/app/src/androidTest/java/com/nsc/covidscore/MainActivityTest.java
+++ b/app/src/androidTest/java/com/nsc/covidscore/MainActivityTest.java
@@ -1,16 +1,29 @@
 package com.nsc.covidscore;
 
+import android.app.Instrumentation;
+import android.provider.Settings;
+import android.view.View;
+
 import androidx.test.espresso.NoMatchingViewException;
 import androidx.test.espresso.PerformException;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.By;
+import androidx.test.uiautomator.UiDevice;
+import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiObject2;
+import androidx.test.uiautomator.UiObjectNotFoundException;
+import androidx.test.uiautomator.UiSelector;
 
 import org.junit.FixMethodOrder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
@@ -21,6 +34,7 @@ import static androidx.test.espresso.action.ViewActions.swipeDown;
 import static androidx.test.espresso.action.ViewActions.swipeUp;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.*;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -39,9 +53,7 @@ public class MainActivityTest {
         try {
             Thread.sleep(8000); // Time for app to load
             try { // Are we in the LocationManualSelectionFragment?
-                // select state
-                onView(withId(R.id.state_spinner)).perform(click());
-                onData(allOf(is(instanceOf(String.class)), is("California"))).perform(click());
+                onView(withId(R.id.state_spinner)).check(matches(isDisplayed()));
             } catch (NoMatchingViewException | PerformException ex) {
                 // We are in RiskDetailFragment - click select new
                 onView(withId(R.id.activeCounty)).check(matches(not(withText(""))));
@@ -61,13 +73,16 @@ public class MainActivityTest {
             // click submit
             onView(withId(R.id.submit_btn)).perform(click());
 
-            Thread.sleep(5000);
-            onView(withId(R.layout.fragment_location_selection)).check(matches(isDisplayed()));
+            Thread.sleep(8000);
+
+            // This should throw a NoMatchingViewException
+            onView(withId(R.id.location_entry_tv)).perform(click());
         } catch (NoMatchingViewException | PerformException ex) {
             // pass over this test to avoid crashing, we're in the RiskDetailPageFragment
             // inside the RiskDetailPageFragment
             onView(withId(R.id.activeCounty)).check(matches(not(withText(""))));
         }
+        onView(withId(R.id.risk_detail_frag)).check(matches(isDisplayed()));
     }
 
     @Test
@@ -116,16 +131,25 @@ public class MainActivityTest {
             onView(withId(R.id.activeCounty)).check(matches(not(withText(""))));
         }
     }
-//
+
+    // This test works locally - uncomment and try it!
+    // TODO: find a way to disable/enable connectivity that works with CircleCI
 //    @Test
-//    public void t3_canSelectNewLocation() throws InterruptedException {
-//        Thread.sleep(1000);
-//        onView(withId(R.id.fullscreen_content_controls)).perform(swipeDown());
-//        onView(withId(R.id.select_location_btn)).perform(click());
+//    public void t3_checksInternet() throws InterruptedException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException, UiObjectNotFoundException {
+//        Thread.sleep(8000); // Time for app to load
+//        try { // Are we in the LocationManualSelectionFragment?
+//            // select state
+//            onView(withId(R.id.state_spinner)).perform(click());
+//            onData(allOf(is(instanceOf(String.class)), is("California"))).perform(click());
+//        } catch (NoMatchingViewException | PerformException ex) {
+//            // We are in RiskDetailFragment - click select new
+//            onView(withId(R.id.select_location_btn)).perform(click());
+//        }
+//        // In LocationManualSelectionFragment
 //
-//        // click submit
-//        onView(withId(R.id.submit_btn)).perform(click());
-//        onView(withId(R.id.loadingTextView)).check(matches(withText("Please pick a state and county")));
+//        // disable wifi & data
+//        InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand("svc wifi disable");
+//        InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand("svc data disable");
 //
 //        // select state
 //        onView(withId(R.id.state_spinner)).perform(click());
@@ -135,47 +159,18 @@ public class MainActivityTest {
 //        onView(withId(R.id.county_spinner)).perform(click());
 //        onData(allOf(is(instanceOf(String.class)), is("king"))).perform(click());
 //
-//        Thread.sleep(3000);
-//        pressBack();
+//        // submit
+//        onView(withId(R.id.submit_btn)).perform(click());
+//        onView(withId(R.id.loadingTextView)).check(matches(withText(R.string.no_internet)));
+//
+//        // enable wifi & data
+//        InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand("svc wifi enable");
+//        InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand("svc data enable");
+//
+//        Thread.sleep(2000);
+//
+//        // submit
+//        onView(withId(R.id.submit_btn)).perform(click());
+//        onView(withId(R.id.loadingTextView)).check(matches(withText(R.string.loading_data)));
 //    }
-
-    @Test
-    public void t3_checksInternet() throws InterruptedException {
-        Thread.sleep(8000); // Time for app to load
-        try { // Are we in the LocationManualSelectionFragment?
-            // select state
-            onView(withId(R.id.state_spinner)).perform(click());
-            onData(allOf(is(instanceOf(String.class)), is("California"))).perform(click());
-        } catch (NoMatchingViewException | PerformException ex) {
-            // We are in RiskDetailFragment - click select new
-            onView(withId(R.id.select_location_btn)).perform(click());
-        }
-        // In LocationManualSelectionFragment
-
-        // disable wifi & data
-        InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand("svc wifi disable");
-        InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand("svc data disable");
-
-        // select state
-        onView(withId(R.id.state_spinner)).perform(click());
-        onData(allOf(is(instanceOf(String.class)), is("Washington"))).perform(click());
-
-        // select county
-        onView(withId(R.id.county_spinner)).perform(click());
-        onData(allOf(is(instanceOf(String.class)), is("king"))).perform(click());
-
-        // submit
-        onView(withId(R.id.submit_btn)).perform(click());
-        onView(withId(R.id.loadingTextView)).check(matches(withText(R.string.no_internet)));
-
-        // enable wifi & data
-        InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand("svc wifi enable");
-        InstrumentationRegistry.getInstrumentation().getUiAutomation().executeShellCommand("svc data enable");
-
-        Thread.sleep(2000);
-
-        // submit
-        onView(withId(R.id.submit_btn)).perform(click());
-        onView(withId(R.id.loadingTextView)).check(matches(withText(R.string.loading_data)));
-    }
 }

--- a/app/src/androidTest/java/com/nsc/covidscore/RoomActivityTest.java
+++ b/app/src/androidTest/java/com/nsc/covidscore/RoomActivityTest.java
@@ -1,0 +1,4 @@
+package com.nsc.covidscore;
+
+public class RoomActivityTest {
+}

--- a/app/src/androidTest/java/com/nsc/covidscore/RoomActivityTest.java
+++ b/app/src/androidTest/java/com/nsc/covidscore/RoomActivityTest.java
@@ -1,4 +1,0 @@
-package com.nsc.covidscore;
-
-public class RoomActivityTest {
-}

--- a/app/src/androidTest/java/com/nsc/covidscore/RoomTest.java
+++ b/app/src/androidTest/java/com/nsc/covidscore/RoomTest.java
@@ -20,8 +20,16 @@ import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
 
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.List;
 
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 

--- a/app/src/androidTest/java/com/nsc/covidscore/RoomTest.java
+++ b/app/src/androidTest/java/com/nsc/covidscore/RoomTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 @RunWith(AndroidJUnit4.class)
 public class RoomTest {

--- a/app/src/androidTest/java/com/nsc/covidscore/TestUtils.java
+++ b/app/src/androidTest/java/com/nsc/covidscore/TestUtils.java
@@ -1,14 +1,10 @@
 package com.nsc.covidscore;
 
 import com.nsc.covidscore.room.CovidSnapshot;
-import com.nsc.covidscore.room.Location;
-
 import java.util.Calendar;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class TestUtils {
@@ -48,4 +44,5 @@ public class TestUtils {
         assertTrue(riskMap.get((Integer) groupSizes[2]) == 87.53);
         assertTrue(riskMap.get((Integer) groupSizes[3]) == 98.38);
     }
+
 }

--- a/app/src/androidTest/java/com/nsc/covidscore/TestUtils.java
+++ b/app/src/androidTest/java/com/nsc/covidscore/TestUtils.java
@@ -24,6 +24,7 @@ public class TestUtils {
 
     public static CovidSnapshot createCovidSnapshot() {
         Calendar calendar = Calendar.getInstance();
+        calendar.roll(Calendar.DAY_OF_YEAR, -2);
         return new CovidSnapshot(resourceId1, 200, 300, 400, calendar);
     }
 

--- a/app/src/main/java/com/nsc/covidscore/Constants.java
+++ b/app/src/main/java/com/nsc/covidscore/Constants.java
@@ -15,6 +15,7 @@ public class Constants {
     public static final String PROVINCE = "province";
     public static final String STATE = "state";
     public static final String STATE_POPULATION = "statePopulation";
+    public static final String API_LOCATION = "apiLocation";
 
     public static final String ACTIVE_COUNTY = "activeCounty";
     public static final String ACTIVE_COUNTRY = "activeCountry";

--- a/app/src/main/java/com/nsc/covidscore/LocationManualSelectionFragment.java
+++ b/app/src/main/java/com/nsc/covidscore/LocationManualSelectionFragment.java
@@ -1,7 +1,6 @@
 package com.nsc.covidscore;
 
 import android.content.Context;
-import android.content.res.AssetManager;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -26,13 +25,10 @@ import com.nsc.covidscore.room.CovidSnapshot;
 import com.nsc.covidscore.room.CovidSnapshotWithLocationViewModel;
 import com.nsc.covidscore.room.Location;
 
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -250,10 +246,10 @@ public class LocationManualSelectionFragment extends Fragment implements Adapter
     }
 
     public interface OnSubmitButtonListener {
-        public void onSubmitButtonClicked(MutableLiveData<CovidSnapshot> mcs, Location selectedLocation);
+        void onSubmitButtonClicked(MutableLiveData<CovidSnapshot> mcs, Location selectedLocation);
     }
 
-    private void makeApiCalls(Location location) {
+    public void makeApiCalls(Location location) {
         Log.i(TAG, "makeApiCalls: CALLED " + location.toString());
         CovidSnapshot covidSnapshot = new CovidSnapshot();
         covidSnapshot.setLocationId(location.getLocationId());
@@ -364,5 +360,10 @@ public class LocationManualSelectionFragment extends Fragment implements Adapter
             }
             Log.d(TAG, "req: getCountryPopulation " + response);
         });
+    }
+
+    public void clearCovidSnapshot() {
+        CovidSnapshot clear = new CovidSnapshot();
+        mutableCovidSnapshot.setValue(clear);
     }
 }

--- a/app/src/main/java/com/nsc/covidscore/MainActivity.java
+++ b/app/src/main/java/com/nsc/covidscore/MainActivity.java
@@ -22,6 +22,7 @@ import com.nsc.covidscore.room.CovidSnapshotWithLocationViewModel;
 import com.nsc.covidscore.room.Location;
 
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.HashMap;
 
 public class MainActivity extends FragmentActivity implements RiskDetailPageFragment.OnSelectLocationButtonListener, LocationManualSelectionFragment.OnSubmitButtonListener {
@@ -29,6 +30,8 @@ public class MainActivity extends FragmentActivity implements RiskDetailPageFrag
 
     private Location lastSavedLocation;
     private CovidSnapshot lastSavedCovidSnapshot = new CovidSnapshot();
+    private boolean firstOpen = true;
+    public boolean isConnected = false;
 
     private CovidSnapshotWithLocationViewModel vm;
     private RequestQueue queue;
@@ -70,7 +73,10 @@ public class MainActivity extends FragmentActivity implements RiskDetailPageFrag
             } else {
                 Log.d(TAG, "Observer returned null CovidSnapshot");
             }
-            loadFragments(savedInstanceState);
+            if (firstOpen) { // Don't do this every time Room is updated
+                loadFragments(savedInstanceState);
+                firstOpen = false;
+            }
         });
 
         // Check Internet Connectivity
@@ -80,11 +86,12 @@ public class MainActivity extends FragmentActivity implements RiskDetailPageFrag
             @Override
             public void onAvailable(Network network) {
                 vm.setConnectionStatus(true);
+                isConnected = true;
             }
             @Override
             public void onLost(Network network) {
                 vm.setConnectionStatus(false);
-                Toast.makeText(context, "No Internet Connection Available", Toast.LENGTH_LONG);
+                isConnected = false;
             }
         });
 
@@ -109,14 +116,15 @@ public class MainActivity extends FragmentActivity implements RiskDetailPageFrag
             if (!lastSavedCovidSnapshot.hasFieldsSet()) { // No saved CovidSnapshot
                 Log.e(TAG, "no saved CovidSnapshot");
                 openLocationSelectionFragment();
-            } else if (vm.getConnectionStatus() == true) { // CovidSnapshot saved, with Internet
+            } else if (vm.getConnectionStatus() == true && !hasBeenUpdatedThisHour()) { // CovidSnapshot saved, with Internet
                 Log.e(TAG, "saved CovidSnapshot exists, update w/ internet");
+                rerunApis(vm.getMapOfLocationsById().get(lastSavedCovidSnapshot.getLocationId()));
             } else { // CovidSnapshot saved, no internet
-                Log.e(TAG, "saved CovidSnapshot exists, no internet");
+                Log.e(TAG, "saved CovidSnapshot exists, no internet or saved this hour");
+                Toast.makeText(context, "No Internet Connection Available", Toast.LENGTH_LONG);
                 openRiskDetailPageFragment();
             }
         }
-
     }
 
     public void openRiskDetailPageFragment() {
@@ -189,6 +197,20 @@ public class MainActivity extends FragmentActivity implements RiskDetailPageFrag
         transaction.commit();
         mcs.setValue(new CovidSnapshot());
         //  selectedLocation = new Location();
+    }
+
+    public void rerunApis(Location location) {
+        // Create a new Location Selection Fragment
+        LocationManualSelectionFragment lmsf = new LocationManualSelectionFragment();
+        Bundle bundle = new Bundle();
+        // If this exists in bundle, it will automatically run the APIs
+        bundle.putSerializable(Constants.API_LOCATION, location);
+        lmsf.setArguments(bundle);
+        getSupportFragmentManager()
+                .beginTransaction()
+                .add(R.id.fragContainer, lmsf, Constants.FRAGMENT_LMSF)
+                .hide(lmsf)
+                .addToBackStack(null).commit();
     }
 
     public void openLocationSelectionFragment() {
@@ -274,5 +296,19 @@ public class MainActivity extends FragmentActivity implements RiskDetailPageFrag
     @Override
     public void onSubmitButtonClicked(MutableLiveData<CovidSnapshot> mcs, Location selectedLocation) {
         openNewRiskDetailPageFragment(mcs, selectedLocation);
+    }
+
+    private boolean hasBeenUpdatedThisHour() {
+        Calendar lastSaved = lastSavedCovidSnapshot.getLastUpdated();
+        Calendar lastSavedHour = Calendar.getInstance();
+        lastSavedHour.clear();
+        lastSavedHour.set(lastSaved.get(Calendar.YEAR), lastSaved.get(Calendar.MONTH), lastSaved.get(Calendar.DAY_OF_MONTH));
+        lastSavedHour.set(Calendar.HOUR_OF_DAY, lastSaved.get(Calendar.HOUR_OF_DAY));
+        Calendar now = Calendar.getInstance();
+        Calendar nowHour = Calendar.getInstance();
+        nowHour.clear();
+        nowHour.set(now.get(Calendar.YEAR), now.get(Calendar.MONTH), now.get(Calendar.DAY_OF_MONTH));
+        nowHour.set(Calendar.HOUR_OF_DAY, now.get(Calendar.HOUR_OF_DAY));
+        return !nowHour.equals(lastSavedHour);
     }
 }

--- a/app/src/main/java/com/nsc/covidscore/api/Requests.java
+++ b/app/src/main/java/com/nsc/covidscore/api/Requests.java
@@ -134,7 +134,7 @@ public class Requests {
      */
     public static void getStatePopulation(Context context, Location location, final VolleyStringCallback cb) {
         final String TAG = Constants.STATE_POPULATION;
-        Log.i(TAG, "getStatePopulation: FAILED LOCATION " + location);
+        Log.i(TAG, "getStatePopulation: FAILED LOCATION " + location); // TODO: Why does this say FAILED?
         StringBuilder url = new StringBuilder(
                 "https://api.census.gov/data/2019/pep/population?get=NAME,POP&for=state:")
                 .append(location.getStateFips()).append("&key=")

--- a/app/src/main/java/com/nsc/covidscore/room/CovidSnapshotWithLocationViewModel.java
+++ b/app/src/main/java/com/nsc/covidscore/room/CovidSnapshotWithLocationViewModel.java
@@ -26,7 +26,7 @@ public class CovidSnapshotWithLocationViewModel extends AndroidViewModel {
 
     private CovidSnapshotWithLocationRepository repo;
     private Context context;
-
+    private boolean isConnected;
 
     private HashMap<String, List<Location>> mapOfLocationsByState = new HashMap<>();
     private HashMap<Integer, Location> mapOfLocationsById = new HashMap<>();
@@ -35,6 +35,7 @@ public class CovidSnapshotWithLocationViewModel extends AndroidViewModel {
         super(application);
         repo = new CovidSnapshotWithLocationRepository(application);
         context = application.getApplicationContext();
+        isConnected = false;
         fillLocationsMaps();
     }
 
@@ -91,6 +92,14 @@ public class CovidSnapshotWithLocationViewModel extends AndroidViewModel {
         } catch (IOException | JSONException exception) {
             exception.printStackTrace();
         }
+    }
+
+    public void setConnectionStatus(boolean connected) {
+        isConnected = connected;
+    }
+
+    public boolean getConnectionStatus() {
+        return isConnected;
     }
 }
 

--- a/app/src/main/res/layout/fragment_risk_detail.xml
+++ b/app/src/main/res/layout/fragment_risk_detail.xml
@@ -85,6 +85,7 @@
                     android:elevation="10dp"
                     app:barrierMargin="@dimen/text_margin"
                     android:translationZ="0dp"
+                    android:layout_marginBottom="40dp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/totalPopsCardView">
 

--- a/app/src/main/res/layout/fragment_risk_detail.xml
+++ b/app/src/main/res/layout/fragment_risk_detail.xml
@@ -105,7 +105,7 @@
         android:layout_width="match_parent"
         android:textSize="@dimen/std_text_size"
         android:background="@color/colorAccentLight"
-        android:paddingVertical="8dp"
+        android:padding="8dp"
         android:layout_alignParentBottom="true"
         android:layout_gravity="bottom"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="risk_assessment">Risk Assessment</string>
     <string name="group_size">Group Size</string>
     <string name="risk_of_being_exposed_to_covid">Risk of COVID exposure</string>
+    <string name="no_internet">No Internet Connection Available</string>
 
     <string-array name="group_sizes">
         <item>10</item>


### PR DESCRIPTION
## Summary
Closes Issue #45 

Adds the ability to check whether the user is connected to a network via wifi or data. 
If the user IS connected AND there is saved Room data (from more than an hour ago), the app will automatically rerun the APIs before loading the data. 
If the user IS NOT connected, then instead of running APIs from the LocationManualSelectionFragment, a message is displayed about not having internet access.

If there are many changes, make a list of them
* small visual modification of RiskDetailFragment
* adds a boolean to check if this is the first time opening, so that we don't recreate fragments every time Room gets updated
* to rerun the API calls, a LCSF is created *secretly* (hidden) so that it can run the APIs and then create the RiskDetailFragment

## Checklist
- [x] New tests added to account for changes in this MR
- [x] All tests passing locally
- [ ] All tests passing on CircleCI
- [x] Assigned at least 2 reviewers
