### PR TITLE
Ab issue 61

### DIFF
--- a/app/src/main/java/com/nsc/covidscore/AboutFragment.java
+++ b/app/src/main/java/com/nsc/covidscore/AboutFragment.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 
 import android.view.LayoutInflater;
@@ -39,6 +40,8 @@ public class AboutFragment extends Fragment {
         ImageButton censusLink = view.findViewById(R.id.censusLink);
         ImageButton appLink = view.findViewById(R.id.appGithubLink);
         ImageButton diseaseLink = view.findViewById(R.id.diseaseGithubLink);
+
+        ((AppCompatActivity)getActivity()).getSupportActionBar().setTitle(R.string.aboutTitle);
 
         censusLink.setOnClickListener(v -> {
             Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.census.gov/data/developers/data-sets/popest-popproj/popest.html"));

--- a/app/src/main/java/com/nsc/covidscore/LocationManualSelectionFragment.java
+++ b/app/src/main/java/com/nsc/covidscore/LocationManualSelectionFragment.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModelProvider;
@@ -95,6 +96,8 @@ public class LocationManualSelectionFragment extends Fragment implements Adapter
     @Override
     public void onViewCreated(@NonNull View v, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(v, savedInstanceState);
+
+        ((AppCompatActivity)getActivity()).getSupportActionBar().setTitle("");
 
         MainActivity main = (MainActivity) getActivity();
 

--- a/app/src/main/java/com/nsc/covidscore/MainActivity.java
+++ b/app/src/main/java/com/nsc/covidscore/MainActivity.java
@@ -127,8 +127,8 @@ public class MainActivity extends AppCompatActivity implements
 
                     covidSnapshotNavList.add(snapshotListFromDb.get(i));
 
+                    nvDrawer.getMenu().getItem(i).setTitle(recentLocation.toDrawerItemTitleFormat());
                     nvDrawer.getMenu().getItem(i).setVisible(true);
-                    nvDrawer.getMenu().getItem(i).setTitle(recentLocation.toApiFormat());
                 }
                 nvDrawer.getMenu().getItem(0).setChecked(true);
             }
@@ -217,6 +217,7 @@ public class MainActivity extends AppCompatActivity implements
 
             Bundle bundle = makeRiskDetailPageBundle(cs, selectedLocation);
             riskDetailPageFragment.setArguments(bundle);
+
 
             transaction.replace(R.id.fragContainer, riskDetailPageFragment, Constants.FRAGMENT_RDPF);
             transaction.addToBackStack(null);

--- a/app/src/main/java/com/nsc/covidscore/RiskDetailPageFragment.java
+++ b/app/src/main/java/com/nsc/covidscore/RiskDetailPageFragment.java
@@ -1,5 +1,6 @@
 package com.nsc.covidscore;
 
+import android.app.Activity;
 import android.content.res.Resources;
 import android.graphics.Typeface;
 import android.os.Bundle;
@@ -15,6 +16,7 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 
 import java.util.ArrayList;
@@ -90,6 +92,7 @@ public class RiskDetailPageFragment extends Fragment {
 
         View v = inflater.inflate(R.layout.fragment_risk_detail, container, false);
         super.onCreate(savedInstanceState);
+
         Log.d(TAG, "onCreateView invoked");
         return v;
     }
@@ -133,6 +136,8 @@ public class RiskDetailPageFragment extends Fragment {
 
         if (bundle != null) {
             currentLocation = bundle.getString(Constants.CURRENT_LOCATION);
+
+            ((AppCompatActivity)getActivity()).getSupportActionBar().setTitle(currentLocation);
 
             activeCounty = bundle.getString(Constants.ACTIVE_COUNTY);
             activeState = bundle.getString(Constants.ACTIVE_STATE);
@@ -178,7 +183,7 @@ public class RiskDetailPageFragment extends Fragment {
 
             lastUpdatedV.setText(lastUpdated);
 
-            Log.i(TAG, "onCreateView: Bundle received from LocationManualSelectionFragment");
+            Log.i(TAG, "onViewCreated: Bundle received from LocationManualSelectionFragment");
         }
 
         riskTrendChart = v.findViewById(R.id.lineGraph);

--- a/app/src/main/java/com/nsc/covidscore/room/Location.java
+++ b/app/src/main/java/com/nsc/covidscore/room/Location.java
@@ -105,9 +105,15 @@ public class Location implements Serializable {
         return county.toLowerCase() + "," + state.toLowerCase();
     }
 
+    public String toDrawerItemTitleFormat() {
+        return county + ", " + state;
+    }
+
     public boolean hasFieldsSet() {
-        boolean notNull = (this.county != null && this.state != null) && (this.countyFips != null && this.stateFips != null);
-        boolean notEmpty = (!this.county.isEmpty() && !this.state.isEmpty()) && (!this.countyFips.isEmpty() && !this.stateFips.isEmpty());
+        boolean notNull = (this.county != null && this.state != null) &&
+                (this.countyFips != null && this.stateFips != null);
+        boolean notEmpty = (!this.county.isEmpty() && !this.state.isEmpty()) &&
+                (!this.countyFips.isEmpty() && !this.stateFips.isEmpty());
         return notNull && notEmpty;
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -48,7 +48,7 @@
     <!-- Note: `android:layout_gravity` needs to be set to 'start' -->
     <com.google.android.material.navigation.NavigationView
         android:id="@+id/nvView"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="start"
         android:background="@android:color/white"

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -2,7 +2,6 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#FFFFFF">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="versionText">0.4.0</string>
     <string name="versionLabel">Version</string>
     <string name="appTitle">CovidScore</string>
+    <string name="aboutTitle">About</string>
     <string name="censusAttributionText">Note: This app uses the Census Bureau Data API but is not endorsed or certified by the Census Bureau.</string>
     <string name="aboutAppHeading">About The App</string>
     <string name="aboutPopulationLabel">Population</string>


### PR DESCRIPTION
## Summary
Closes #61

Drawer item location names are formatted with proper spacing and capitalization
 Long location names are not cut off in the drawer
 App bar displays location/page title and remains at top of screen after scrolling down
 App bar title is correct thru 'back' and location changes

## Checklist
- [x] All tests passing locally
- [x] All tests passing on CircleCI
- [x] Assigned at least 2 reviewers
