### PR TITLE
Hide API key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,13 +99,13 @@ jobs:
   build_debug:
     <<: *android_config
     steps:
+      - *decode_apikeys_properties
       - checkout
       - *restore_cache
       - run:
           name: Download dependencies
           command: ./gradlew androidDependencies
       - *save_cache
-      - *decode_apikeys_properties
       - *export_gservices_key
       - *decode_gservices_key
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
   build_debug:
     <<: *android_config
     steps:
+      - run: echo apikeys.properties > apikeys.properties
       - checkout
       - *restore_cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,6 @@ jobs:
   build_debug:
     <<: *android_config
     steps:
-      - run: echo apikeys.properties > apikeys.properties
       - checkout
       - *restore_cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *decode_apikeys_properties
       - *restore_cache
       - run:
           name: Download dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *decode_apikeys_properties
       - *restore_cache
       - run:
           name: Download dependencies
@@ -146,6 +147,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *decode_apikeys_properties
       - *restore_cache
       - run:
           name: Download dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,12 @@ references:
       name: Decode Google Cloud credentials
       command: echo $GCLOUD_SERVICE_KEY | base64 -di > ${HOME}/client-secret.json
 
+  # apikeys.properties
+  decode_apikeys_properties: &decode_apikeys_properties
+    run:
+      name: Decode apikeys.properties
+      command: echo $APIKEYS_PROPERTIES | base64 -di > apikeys.properties
+
 jobs:
 
   # Build debug APK for unit tests and an instrumented test APK
@@ -99,6 +105,7 @@ jobs:
           name: Download dependencies
           command: ./gradlew androidDependencies
       - *save_cache
+      - *decode_apikeys_properties
       - *export_gservices_key
       - *decode_gservices_key
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,8 +99,8 @@ jobs:
   build_debug:
     <<: *android_config
     steps:
-      - *decode_apikeys_properties
       - checkout
+      - *decode_apikeys_properties
       - *restore_cache
       - run:
           name: Download dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@
 .externalNativeBuild
 .cxx
 google-services.json
-apikey.properties
+apikeys.properties

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 google-services.json
+apikey.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 apply from: '../jacoco.gradle'
 
-def apikeyPropertiesFile = rootProject.file("apikey.properties")
+def apikeyPropertiesFile = rootProject.file("apikeys.properties")
 def apikeyProperties = new Properties()
 apikeyProperties.load(new FileInputStream(apikeyPropertiesFile))
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,10 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 apply from: '../jacoco.gradle'
 
+def apikeyPropertiesFile = rootProject.file("apikey.properties")
+def apikeyProperties = new Properties()
+apikeyProperties.load(new FileInputStream(apikeyPropertiesFile))
+
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.3"
@@ -12,7 +16,7 @@ android {
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"
-
+        buildConfigField("String", "CENSUS_API_KEY", apikeyProperties['CENSUS_API_KEY'])
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/nsc/covidscore/Constants.java
+++ b/app/src/main/java/com/nsc/covidscore/Constants.java
@@ -1,7 +1,7 @@
 package com.nsc.covidscore;
 
 public class Constants {
-    public static final String CENSUS_API_KEY = "284928f69049b0901d7c04abfacf724536890594";
+    public static final String CENSUS_API_KEY = BuildConfig.CENSUS_API_KEY;
     public static final String COUNTY = "county";
     public static final String COUNTY_HISTORICAL = "countyHistorical";
     public static final String COUNTY_POPULATION = "countyPopulation";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,6 @@
     <string name="app_name">Covid Score</string>
     <string name="settings">Settings</string>
     <string name="manage_locations">Manage Locations</string>
-    <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 
     <string name="drawer_open">Open navigation drawer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,7 +43,7 @@
         that we display to you.</string>
     <string name="aboutDataHeading">Data Sources</string>
     <string name="githubLabel">Check us out on GitHub</string>
-    <string name="versionText">0.5.0</string>
+    <string name="versionText">0.5.1</string>
     <string name="versionLabel">Version</string>
     <string name="appTitle">CovidScore</string>
     <string name="aboutTitle">About</string>


### PR DESCRIPTION
## Summary
Hides the api key for the census bureau from GitHub and ensure that the CircleCI builds and coverage reports don't fail by adding an environment variable to CircleCI

To test:
1. Go to the [Offboarding folder](https://drive.google.com/drive/folders/1hGCHGhtyWEKmahNxUKdZQ1Ra4ND-2WuD) and download `apikeys.properties`
2. Add `apikeys.properties` to the root of the project
3. Select a new location and get a snapshot to ensure the api key is working correctly. 

## Checklist
- [ ] New tests added to account for changes in this MR
- [x] All tests passing locally
- [x] All tests passing on CircleCI
- [x] Assigned at least 2 reviewers
